### PR TITLE
:recycle: Add round end subscription

### DIFF
--- a/src/redux/Round/index.ts
+++ b/src/redux/Round/index.ts
@@ -59,18 +59,14 @@ export const slice = createSlice({
     stop: (state: RoundState) => {
       state.isStarted = false;
     },
-    fail: (state: RoundState, action: PayloadAction<payloads.round.Fail>) => {
+    end: (state: RoundState, action: PayloadAction<payloads.round.End>) => {
+      state.score = action.payload.data.score;
       state.lives = action.payload.data.lives;
       state.isSuccess = false;
       state.isStarted = false;
-    },
-    success: (
-      state: RoundState,
-      action: PayloadAction<payloads.round.Success>
-    ) => {
-      state.score = action.payload.data.score;
-      state.isSuccess = true;
       state.isStarted = false;
+      state.isSuccess =
+        action.payload.data.endType === enums.round.EndType.success;
     },
     tick: (state: RoundState, action: PayloadAction<payloads.round.Tick>) => {
       state.members = action.payload.data.members;

--- a/src/redux/WebSocket/actions/subscribe/round.ts
+++ b/src/redux/WebSocket/actions/subscribe/round.ts
@@ -22,12 +22,7 @@ export const tick = createSubscribeAction(
   RoundActions.tick.type
 );
 
-export const fail = createSubscribeAction(
-  events.round.fail,
-  RoundActions.fail.type
-);
-
-export const Success = createSubscribeAction(
-  events.round.success,
-  RoundActions.success.type
+export const end = createSubscribeAction(
+  events.round.end,
+  RoundActions.end.type
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1140,7 +1140,7 @@
 
 "@colobobo/library@https://github.com/colobobo/library":
   version "1.0.0"
-  resolved "https://github.com/colobobo/library#028a9507762e10e7b8465de864675b37a1c042fc"
+  resolved "https://github.com/colobobo/library#45005359de3eecbfc529e33bc3781013a2a96676"
   dependencies:
     prettier "^2.0.1"
     tslint "^6.1.0"


### PR DESCRIPTION
## Description
This PR fixes support for @colobobo/library with new `round:end` event.

## Todos
- [x] Add round en subscription
- [x] Remove round success
